### PR TITLE
Add `tslib` as a dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "rollup-plugin-dts": "^6.1.1",
         "ts-jest": "^29.2.6",
         "ts-node": "^10.9.2",
+        "tslib": "^2.8.1",
         "typescript": "^5.8.2"
       }
     },
@@ -6292,6 +6293,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "rollup-plugin-dts": "^6.1.1",
     "ts-jest": "^29.2.6",
     "ts-node": "^10.9.2",
+    "tslib": "^2.8.1",
     "typescript": "^5.8.2"
   }
 }


### PR DESCRIPTION
This pull request adds `tslib` as a development dependency to ensure compatibility and streamline TypeScript builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies to include an additional package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->