### PR TITLE
feat: add `moveDataField` functionality to `TemplateDraftsNamespace`

### DIFF
--- a/src/dpp/template-drafts/template-draft.dtos.ts
+++ b/src/dpp/template-drafts/template-draft.dtos.ts
@@ -83,7 +83,7 @@ export enum MoveDirection {
   DOWN = "down",
 }
 
-export interface MoveSectionDraftDto {
+export interface MoveDto {
   type: MoveType;
   direction: MoveDirection;
 }

--- a/src/dpp/template-drafts/template-drafts.namespace.ts
+++ b/src/dpp/template-drafts/template-drafts.namespace.ts
@@ -2,7 +2,7 @@ import { AxiosInstance } from "axios";
 import {
   DataFieldDraftCreateDto,
   DataFieldDraftUpdateDto,
-  MoveSectionDraftDto,
+  MoveDto,
   PublicationCreateDto,
   SectionDraftCreateDto,
   SectionDraftUpdateDto,
@@ -100,13 +100,21 @@ export class TemplateDraftsNamespace {
     );
   }
 
-  public async moveSection(
-    draftId: string,
-    sectionId: string,
-    data: MoveSectionDraftDto,
-  ) {
+  public async moveSection(draftId: string, sectionId: string, data: MoveDto) {
     return this.axiosInstance.post<TemplateDraftDto>(
       `${this.draftsEndpoint}/${draftId}/sections/${sectionId}/move`,
+      data,
+    );
+  }
+
+  public async moveDataField(
+    draftId: string,
+    sectionId: string,
+    dataFieldId: string,
+    data: MoveDto,
+  ) {
+    return this.axiosInstance.post<TemplateDraftDto>(
+      `${this.draftsEndpoint}/${draftId}/sections/${sectionId}/data-fields/${dataFieldId}/move`,
       data,
     );
   }

--- a/tests/dpp/dpp-api-client.spec.ts
+++ b/tests/dpp/dpp-api-client.spec.ts
@@ -307,6 +307,21 @@ describe("ApiClient", () => {
       });
     });
 
+    it("should move data field", async () => {
+      const response = await sdk.dpp.templateDrafts.moveDataField(
+        templateDraft.id,
+        sectionDraft.id,
+        dataFieldDraft.id,
+        {
+          type: MoveType.POSITION,
+          direction: MoveDirection.DOWN,
+        },
+      );
+      expect(response.data).toEqual({
+        ...templateDraft,
+      });
+    });
+
     it("should get all template drafts", async () => {
       const response = await sdk.dpp.templateDrafts.getAll();
       expect(response.data).toEqual(draftsOfOrganization);

--- a/tests/dpp/handlers/template-draft.ts
+++ b/tests/dpp/handlers/template-draft.ts
@@ -104,6 +104,14 @@ export const templateDraftsHandlers = [
       });
     },
   ),
+  http.post(
+    `${draftEndpointUrl}/${templateDraft.id}/sections/${sectionDraft.id}/data-fields/${dataFieldDraft.id}/move`,
+    async () => {
+      return HttpResponse.json(templateDraft, {
+        status: 201,
+      });
+    },
+  ),
   http.patch(
     `${draftEndpointUrl}/${templateDraft.id}/sections/${sectionDraft.id}/data-fields/${dataFieldDraft.id}`,
     async () => {


### PR DESCRIPTION
Introduce `moveDataField` method in `TemplateDraftsNamespace` to support data field reordering with `MoveType` and `MoveDirection` enums. Update DTOs, handlers, and tests with the new functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - You can now move individual data fields within a template draft.

- Refactor
  - Standardized the move request format across move operations.
  - Updated the API to require an explicit data field ID when moving a field.
  - Aligned section and data-field move operations to use the same request structure.

- Tests
  - Added automated tests covering the data-field move workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->