### PR TITLE
Refactor exports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,37 +1,97 @@
-export * from "./open-dpp-client";
-export * from "./dpp/models/models.namespace";
-export * from "./dpp/models/model.dtos";
-export * from "./dpp/items/items.namespace";
-export * from "./dpp/items/item.dtos";
-export * from "./dpp/organizations/organization.dtos";
-export * from "./dpp/organizations/organizations.namespace";
-export * from "./dpp/template-drafts/template-draft.dtos";
-export * from "./dpp/template-drafts/template-drafts.namespace";
-export * from "./dpp/templates/template.dtos";
-export * from "./dpp/templates/templates.namespace";
-export * from "./dpp/unique-product-identifiers/unique-product-identifiers.dtos";
-export * from "./dpp/unique-product-identifiers/unique-product-identifiers.namespace";
-export * from "./dpp/users/user.dtos";
-export * from "./dpp/data-modelling/data-field.dto";
-export * from "./dpp/data-modelling/section.dto";
-export * from "./dpp/data-modelling/granularity-level";
-export * from "./dpp/passport-data/data-value.dto";
-export * from "./dpp/integrations/aas-integration.dtos";
-export * from "./dpp/integrations/aas-integration.namespace";
-export * from "./dpp/product-passport/product-passport.dtos";
-export * from "./dpp/product-passport/product-passports.namespace";
-export * from "./dpp/dpp-api-client";
+export { OpenDppClient } from "./open-dpp-client";
+export { ModelsNamespace } from "./dpp/models/models.namespace";
+export type { ModelCreateDto, ModelDto } from "./dpp/models/model.dtos";
+export { ItemsNamespace } from "./dpp/items/items.namespace";
+export type { ItemDto } from "./dpp/items/item.dtos";
+export type {
+  OrganizationCreateDto,
+  OrganizationDto,
+} from "./dpp/organizations/organization.dtos";
+export { OrganizationsNamespace } from "./dpp/organizations/organizations.namespace";
+export {
+  VisibilityLevel,
+  MoveType,
+  MoveDirection,
+} from "./dpp/template-drafts/template-draft.dtos";
+export type {
+  PublicationDto,
+  PublicationCreateDto,
+  TemplateDraftDto,
+  TemplateDraftGetAllDto,
+  DataFieldDraftCreateDto,
+  SectionDraftCreateDto,
+  TemplateDraftCreateDto,
+  DataFieldDraftUpdateDto,
+  SectionDraftUpdateDto,
+  TemplateDraftUpdateDto,
+  MoveDto,
+} from "./dpp/template-drafts/template-draft.dtos";
+export { TemplateDraftsNamespace } from "./dpp/template-drafts/template-drafts.namespace";
+export type {
+  TemplateDto,
+  TemplateGetAllDto,
+} from "./dpp/templates/template.dtos";
+export { TemplatesNamespace } from "./dpp/templates/templates.namespace";
+export type {
+  UniqueProductIdentifierDto,
+  UniqueProductIdentifierReferenceDto,
+  UniqueProductIdentifierMetadataDto,
+} from "./dpp/unique-product-identifiers/unique-product-identifiers.dtos";
+export { UniqueProductIdentifiersNamespace } from "./dpp/unique-product-identifiers/unique-product-identifiers.namespace";
+export type { UserDto } from "./dpp/users/user.dtos";
+export { DataFieldType } from "./dpp/data-modelling/data-field.dto";
+export type { DataFieldDto } from "./dpp/data-modelling/data-field.dto";
+export { SectionType } from "./dpp/data-modelling/section.dto";
+export type { SectionDto } from "./dpp/data-modelling/section.dto";
+export { GranularityLevel } from "./dpp/data-modelling/granularity-level";
+export type {
+  DataValueDto,
+  ProductPassportDataDto,
+} from "./dpp/passport-data/data-value.dto";
+export { AssetAdministrationShellType } from "./dpp/integrations/aas-integration.dtos";
+export type {
+  AasConnectionDto,
+  AasConnectionGetAllDto,
+  AasFieldAssignmentDto,
+  AasPropertyDto,
+  AasPropertyWithParentDto,
+  CreateAasConnectionDto,
+  UpdateAasConnectionDto,
+} from "./dpp/integrations/aas-integration.dtos";
+export { AasIntegrationNamespace } from "./dpp/integrations/aas-integration.namespace";
+export type {
+  ProductPassportDto,
+  DataSectionDto,
+} from "./dpp/product-passport/product-passport.dtos";
+export { ProductPassportsNamespace } from "./dpp/product-passport/product-passports.namespace";
+export { DppApiClient } from "./dpp/dpp-api-client";
 
-export * from "./marketplace/passport-templates/passport-templates.namespace";
-export * from "./marketplace/passport-templates/passport-templates.dtos";
-export * from "./marketplace/marketplace-api-client";
+export { PassportTemplatesNamespace } from "./marketplace/passport-templates/passport-templates.namespace";
+export { Sector } from "./marketplace/passport-templates/passport-templates.dtos";
+export type {
+  PassportTemplateCreateDto,
+  PassportTemplateDto,
+  PassportTemplateGetAllDto,
+} from "./marketplace/passport-templates/passport-templates.dtos";
+export { MarketplaceApiClient } from "./marketplace/marketplace-api-client";
 
-export * from "./agent-server/ai-configuration/ai-configuration.dtos";
-export * from "./agent-server/ai-configuration/ai-configuration.namespace";
-export * from "./agent-server/agent-server-api-client";
+export { AiProvider } from "./agent-server/ai-configuration/ai-configuration.dtos";
+export type {
+  AiConfigurationDto,
+  AiConfigurationUpsertDto,
+} from "./agent-server/ai-configuration/ai-configuration.dtos";
+export { AiConfigurationNamespace } from "./agent-server/ai-configuration/ai-configuration.namespace";
+export { AgentServerApiClient } from "./agent-server/agent-server-api-client";
 
-export * from "./analytics/passport-metric/passport-metric.dtos";
-export * from "./analytics/passport-metric/passport-metric.namespace";
-export * from "./analytics/analytics-api-client";
-
-export { VisibilityLevel } from "./dpp/template-drafts/template-draft.dtos";
+export { PassportMetricNamespace } from "./analytics/passport-metric/passport-metric.namespace";
+export {
+  MeasurementType,
+  TimePeriod,
+} from "./analytics/passport-metric/passport-metric.dtos";
+export type {
+  PageViewCreateDto,
+  PageViewDto,
+  PassportMeasurementDto,
+  PassportMetricQueryDto,
+} from "./analytics/passport-metric/passport-metric.dtos";
+export { AnalyticsApiClient } from "./analytics/analytics-api-client";


### PR DESCRIPTION
This pull request refactors the exports in `src/index.ts` to use named exports instead of wildcard (`export *`) exports. This change makes the module's public API more explicit and type-safe, and it clarifies which types and classes are available to consumers of the package. Additionally, the exports are reorganized to group related types and namespaces together, improving maintainability and discoverability.

**Refactor to named and explicit exports:**

* Replaces all wildcard exports with explicit named exports for classes, types, enums, and namespaces throughout the module, making the API surface more clear and maintainable.
* Groups related exports together by theme (e.g., DPP models, marketplace, agent server, analytics), improving readability and discoverability.

**API improvements:**

* Exposes only the necessary types, enums, and classes, reducing the risk of accidental usage of internal or deprecated APIs.
* Adds explicit type exports for DTOs and enums that were previously only available via wildcard exports, making import statements more concise and type-safe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Reworked public API to use explicit named and type-only exports instead of wildcards, providing a clearer, more granular surface.
  - Improves tree-shaking and IDE autocompletion. No runtime behavior changes.
  - Note: Update your imports to use named exports.

- New Features
  - Added new named exports for various clients, namespaces, enums, and DTOs to support more targeted consumption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->